### PR TITLE
Update vcolorpicker return None on cancel or exit.

### DIFF
--- a/vcolorpicker/vcolorpicker.py
+++ b/vcolorpicker/vcolorpicker.py
@@ -117,7 +117,7 @@ class ColorPicker(QDialog):
             return (r,g,b)
 
         else:
-            return self.lastcolor
+            return None
 
     # Update Functions
     def hsvChanged(self):


### PR DESCRIPTION
As mentioned in issue #10. Mini fix to return None when exiting or canceling the picking of a colour. 