### PR TITLE
Add alpha channel support in ColorPicker class

### DIFF
--- a/vcolorpicker/vcolorpicker.py
+++ b/vcolorpicker/vcolorpicker.py
@@ -117,6 +117,7 @@ class ColorPicker(QDialog):
             return (r,g,b)
 
         else:
+            if self.usingAlpha: return (r, g, b, self.alpha)
             return self.lastcolor
 
     # Update Functions


### PR DESCRIPTION
I was having crash problem when pressing the Cancel button in ColorPicker and I've fixed it.
There was an error in the getColor function of this library.
If it couldn't execute, meaning if cancel was pressed, it was returning LastColor.
However, if Alpha was enabled, it should have returned with alpha.
This way, program crashes when the Cancel button is pressed were prevented.